### PR TITLE
Fixes #176

### DIFF
--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -7,11 +7,18 @@ Manages connection pooling among other things.
 
 # Main python libraries
 import os
+import logging
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import event
 from sqlalchemy import exc
 from sqlalchemy.pool import QueuePool
+import sqlalchemy
+
+logging.basicConfig()
+logging.getLogger('sqlalchemy.pool').setLevel(logging.DEBUG)
+logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
 
 # pattoo libraries
 from pattoo_shared import log

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -71,7 +71,7 @@ def main():
             pool_timeout=pool_timeout)
 
         # Fix for multiprocessing on engines.
-        _add_engine_pidguard(db_engine)
+        # _add_engine_pidguard(db_engine)
 
         # Create database session object
         POOL = scoped_session(

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -14,11 +14,6 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import event
 from sqlalchemy import exc
 from sqlalchemy.pool import QueuePool
-import sqlalchemy
-
-logging.basicConfig()
-logging.getLogger('sqlalchemy.pool').setLevel(logging.DEBUG)
-logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
 
 # pattoo libraries
 from pattoo_shared import log
@@ -29,7 +24,7 @@ from pattoo.configuration import ConfigPattoo as Config
 #############################################################################
 POOL = None
 URL = None
-ENGINE = None
+
 
 def main():
     """Process agent data.
@@ -45,7 +40,6 @@ def main():
     use_mysql = True
     global POOL
     global URL
-    global ENGINE
     pool_timeout = 30
     pool_recycle = min(10, pool_timeout - 10)
 
@@ -66,7 +60,7 @@ def main():
         _add_engine_pidguard(QueuePool)
 
         # Add MySQL to the pool
-        ENGINE = create_engine(
+        db_engine = create_engine(
             URL,
             echo=False,
             echo_pool=False,
@@ -79,14 +73,14 @@ def main():
             pool_timeout=pool_timeout)
 
         # Fix for multiprocessing on engines.
-        _add_engine_pidguard(ENGINE)
+        _add_engine_pidguard(db_engine)
 
         # Create database session object
         POOL = scoped_session(
             sessionmaker(
                 autoflush=True,
                 autocommit=False,
-                bind=ENGINE
+                bind=db_engine
             )
         )
 

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -22,7 +22,7 @@ from pattoo.configuration import ConfigPattoo as Config
 #############################################################################
 POOL = None
 URL = None
-
+ENGINE = None
 
 def main():
     """Process agent data.
@@ -38,6 +38,7 @@ def main():
     use_mysql = True
     global POOL
     global URL
+    global ENGINE
     pool_timeout = 30
     pool_recycle = min(10, pool_timeout - 10)
 
@@ -58,7 +59,7 @@ def main():
         _add_engine_pidguard(QueuePool)
 
         # Add MySQL to the pool
-        db_engine = create_engine(
+        ENGINE = create_engine(
             URL,
             echo=False,
             echo_pool=False,
@@ -71,14 +72,14 @@ def main():
             pool_timeout=pool_timeout)
 
         # Fix for multiprocessing on engines.
-        _add_engine_pidguard(db_engine)
+        _add_engine_pidguard(ENGINE)
 
         # Create database session object
         POOL = scoped_session(
             sessionmaker(
                 autoflush=True,
                 autocommit=False,
-                bind=db_engine
+                bind=ENGINE
             )
         )
 

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -71,7 +71,7 @@ def main():
             pool_timeout=pool_timeout)
 
         # Fix for multiprocessing on engines.
-        # _add_engine_pidguard(db_engine)
+        _add_engine_pidguard(db_engine)
 
         # Create database session object
         POOL = scoped_session(

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -58,20 +58,17 @@ def main():
         _add_engine_pidguard(QueuePool)
 
         # Add MySQL to the pool
-        '''db_engine = create_engine(
-            URL, echo=False,
+        db_engine = create_engine(
+            URL,
+            echo=True,
+            echo_pool=True,
             encoding='utf8',
             poolclass=QueuePool,
             max_overflow=max_overflow,
             pool_size=pool_size,
             pool_pre_ping=True,
             pool_recycle=pool_recycle,
-            pool_timeout=pool_timeout)'''
-
-        db_engine = create_engine(
-            URL, echo=False,
-            encoding='utf8',
-            poolclass=QueuePool)
+            pool_timeout=pool_timeout)
 
         # Fix for multiprocessing on engines.
         _add_engine_pidguard(db_engine)

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -13,6 +13,11 @@ from sqlalchemy import event
 from sqlalchemy import exc
 from sqlalchemy.pool import QueuePool
 
+# Test logging
+import logging
+logging.basicConfig()
+logging.getLogger('sqlalchemy.pool').setLevel(logging.DEBUG)
+
 # pattoo libraries
 from pattoo_shared import log
 from pattoo.configuration import ConfigPattoo as Config

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -13,11 +13,6 @@ from sqlalchemy import event
 from sqlalchemy import exc
 from sqlalchemy.pool import QueuePool
 
-# Test logging
-import logging
-logging.basicConfig()
-logging.getLogger('sqlalchemy.pool').setLevel(logging.DEBUG)
-
 # pattoo libraries
 from pattoo_shared import log
 from pattoo.configuration import ConfigPattoo as Config

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -58,7 +58,7 @@ def main():
         _add_engine_pidguard(QueuePool)
 
         # Add MySQL to the pool
-        db_engine = create_engine(
+        '''db_engine = create_engine(
             URL, echo=False,
             encoding='utf8',
             poolclass=QueuePool,
@@ -66,7 +66,12 @@ def main():
             pool_size=pool_size,
             pool_pre_ping=True,
             pool_recycle=pool_recycle,
-            pool_timeout=pool_timeout)
+            pool_timeout=pool_timeout)'''
+
+        db_engine = create_engine(
+            URL, echo=False,
+            encoding='utf8',
+            poolclass=QueuePool)
 
         # Fix for multiprocessing on engines.
         _add_engine_pidguard(db_engine)

--- a/pattoo/db/__init__.py
+++ b/pattoo/db/__init__.py
@@ -60,8 +60,8 @@ def main():
         # Add MySQL to the pool
         db_engine = create_engine(
             URL,
-            echo=True,
-            echo_pool=True,
+            echo=False,
+            echo_pool=False,
             encoding='utf8',
             poolclass=QueuePool,
             max_overflow=max_overflow,

--- a/pattoo/db/db.py
+++ b/pattoo/db/db.py
@@ -9,7 +9,7 @@ from sqlalchemy import and_
 
 # pattoo libraries
 from pattoo_shared import log
-from pattoo.db import POOL, ENGINE
+from pattoo.db import POOL
 from pattoo.db.models import DataPoint
 
 
@@ -55,9 +55,6 @@ def db_modify(error_code, die=True):
         # Return the Connection to the pool
         session.close()
 
-        # Dispose of it as a multiprocessing protection
-        ENGINE.dispose()
-
 
 @contextmanager
 def db_query(error_code):
@@ -92,9 +89,6 @@ def db_query(error_code):
     finally:
         # Return the Connection to the pool
         session.close()
-
-        # Dispose of it as a multiprocessing protection
-        ENGINE.dispose()
 
 
 def connectivity(die=True):

--- a/pattoo/db/db.py
+++ b/pattoo/db/db.py
@@ -9,7 +9,7 @@ from sqlalchemy import and_
 
 # pattoo libraries
 from pattoo_shared import log
-from pattoo.db import POOL
+from pattoo.db import POOL, ENGINE
 from pattoo.db.models import DataPoint
 
 
@@ -52,7 +52,11 @@ def db_modify(error_code, die=True):
         else:
             log.log2info(error_code, log_message)
     finally:
+        # Return the Connection to the pool
         session.close()
+
+        # Dispose of it as a multiprocessing protection
+        ENGINE.dispose()
 
 
 @contextmanager
@@ -86,7 +90,11 @@ def db_query(error_code):
         log_message = '{}. Unknown error'.format(prefix)
         log.log2info(error_code, log_message)
     finally:
+        # Return the Connection to the pool
         session.close()
+
+        # Dispose of it as a multiprocessing protection
+        ENGINE.dispose()
 
 
 def connectivity(die=True):

--- a/pattoo/db/misc.py
+++ b/pattoo/db/misc.py
@@ -31,8 +31,6 @@ def agent_checksums(agent_id):
             DataPoint.last_timestamp,
             DataPoint.polling_interval,
             DataPoint.idx_datapoint).filter(and_(
-                Glue.idx_datapoint == DataPoint.idx_datapoint,
-                Glue.idx_pair == Pair.idx_pair,
                 Agent.agent_id == agent_id.encode(),
                 DataPoint.idx_agent == Agent.idx_agent
             ))

--- a/pattoo/db/table/data.py
+++ b/pattoo/db/table/data.py
@@ -56,7 +56,8 @@ def insert_rows(items):
                 and_(DataPoint.idx_datapoint == idx_datapoint,
                      DataPoint.enabled == 1)).update(
                          {'last_timestamp': timestamp,
-                          'polling_interval': polling_intervals[idx_datapoint]}
+                          'polling_interval': int(
+                            polling_intervals[idx_datapoint])}
                      )
 
     # Update after updating the last timestamp. Helps to prevent

--- a/pattoo/db/table/datapoint.py
+++ b/pattoo/db/table/datapoint.py
@@ -10,6 +10,7 @@ from pattoo_shared import times
 from pattoo_shared.constants import (
     DATA_INT, DATA_FLOAT, DATA_COUNT64, DATA_COUNT)
 
+
 # Import project libraries
 from pattoo.db import db
 from pattoo.db.models import DataPoint as _DataPoint

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -269,7 +269,6 @@ def _process_data_exception(pattoo_db_records):
     """
     # Initialize key variables
     success = False
-    return True
 
     # Execute
     try:
@@ -312,6 +311,7 @@ def process_db_records(pattoo_db_records):
     # Initialize key variables
     _data = {}
     success = False
+    return True
 
     # Return if there is nothint to process
     if bool(pattoo_db_records) is False:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -4,6 +4,8 @@
 # Standard imports
 import multiprocessing
 import sys
+import time
+import random
 
 # PIP3 imports
 import tblib.pickling_support
@@ -269,6 +271,7 @@ def _process_data_exception(pattoo_db_records):
     """
     # Initialize key variables
     success = False
+    time.sleep(random.random())
 
     # Execute
     try:
@@ -315,8 +318,6 @@ def process_db_records(pattoo_db_records):
     # Return if there is nothint to process
     if bool(pattoo_db_records) is False:
         return success
-
-    return True
 
     # Get DataPoint.idx_datapoint and idx_pair values from db. This is used to
     # speed up the process by reducing the need for future database access.

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -18,7 +18,6 @@ from pattoo_shared import log
 from pattoo.constants import IDXTimestampValue, ChecksumLookup
 from pattoo.ingest import get
 from pattoo.db import misc
-from pattoo.db import ENGINE
 from pattoo.db.table import pair, glue, data, datapoint
 from pattoo.configuration import ConfigIngester as Config
 
@@ -263,19 +262,25 @@ def _process_data_exception(pattoo_db_records):
         pattoo_db_records: List of dicts read from cache files.
 
     Returns:
-        success: True if records have been processed. Required to make
-            pool.join() work correctly when tailing syslog. There have been
-            issues where the processes hang on successful completion but never
-            trigger pool.join(). This methodolgy has reduced the risk.
+        None
 
     """
-    # Initialize key variables
-    success = False
+    # Initialize
+
+    '''
+    Sleep for a short random time. We have seen where on very fast systems
+    SQLAlchemy will hang the creation of multiprocessing subprocesses. The
+    typical behaviour is the creation of one fewer
+    pattoo.db._add_engine_pidguard() log messages than agents to process.
+    These messages correspond to the creation of a subprocess which immediately
+    invalidates a parent process's DB connection that will cause errors
+    if used, which provided the clue to the source of the problem.
+    '''
     time.sleep(random.random())
 
     # Execute
     try:
-        success = process_db_records(pattoo_db_records)
+        process_db_records(pattoo_db_records)
     except Exception as error:
         _exception = sys.exc_info()
         log.log2exception(20132, _exception)
@@ -285,7 +290,7 @@ def _process_data_exception(pattoo_db_records):
         log.log2exception_die(20109, _exception)
 
     # Return
-    return success
+    return None
 
 
 def process_db_records(pattoo_db_records):
@@ -295,10 +300,7 @@ def process_db_records(pattoo_db_records):
         pattoo_db_records: List of dicts read from cache files.
 
     Returns:
-        success: True if records have been processed. Required to make
-            pool.join() work correctly when tailing syslog. There have been
-            issues where the processes hang on successful completion but never
-            trigger pool.join(). This methodolgy has reduced the risk.
+        None
 
     Method:
         1) Get all the idx_datapoint and idx_pair values that exist in the
@@ -313,11 +315,10 @@ def process_db_records(pattoo_db_records):
     """
     # Initialize key variables
     _data = {}
-    success = False
 
     # Return if there is nothint to process
     if bool(pattoo_db_records) is False:
-        return success
+        return
 
     # Get DataPoint.idx_datapoint and idx_pair values from db. This is used to
     # speed up the process by reducing the need for future database access.
@@ -383,7 +384,3 @@ def process_db_records(pattoo_db_records):
     log_message = ('''\
 Finished cache data processing for agent_id: {}'''.format(agent_id))
     log.log2debug(20113, log_message)
-
-    # Return
-    success = True
-    return success

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -104,9 +104,6 @@ class Records(object):
         pattoo_db_records_lists_tuple = self._arguments
         pool_size = self._pool_size
 
-        # Dispose of it as a multiprocessing protection
-        ENGINE.dispose()
-
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
 
@@ -146,9 +143,6 @@ class Records(object):
         log_message = 'Processing {} agents from cache'.format(
             len(pattoo_db_records_lists_tuple))
         log.log2debug(20009, log_message)
-
-        # Dispose of it as a multiprocessing protection
-        ENGINE.dispose()
 
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
@@ -239,6 +233,9 @@ def _process_kvps_exception(pattoo_db_records):
         None
 
     """
+    # Dispose of any connections as a multiprocessing protection
+    ENGINE.dispose()
+
     # Initialize key variables
     result = []
 
@@ -275,6 +272,9 @@ def _process_data_exception(pattoo_db_records):
     """
     # Initialize key variables
     success = False
+
+    # Dispose of any connections as a multiprocessing protection
+    ENGINE.dispose()
 
     # Execute
     try:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -16,6 +16,7 @@ from pattoo_shared import log
 from pattoo.constants import IDXTimestampValue, ChecksumLookup
 from pattoo.ingest import get
 from pattoo.db import misc
+from pattoo.db import ENGINE
 from pattoo.db.table import pair, glue, data, datapoint
 from pattoo.configuration import ConfigIngester as Config
 
@@ -103,6 +104,9 @@ class Records(object):
         pattoo_db_records_lists_tuple = self._arguments
         pool_size = self._pool_size
 
+        # Dispose of it as a multiprocessing protection
+        ENGINE.dispose()
+
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
 
@@ -142,6 +146,9 @@ class Records(object):
         log_message = 'Processing {} agents from cache'.format(
             len(pattoo_db_records_lists_tuple))
         log.log2debug(20009, log_message)
+
+        # Dispose of it as a multiprocessing protection
+        ENGINE.dispose()
 
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -144,8 +144,6 @@ class Records(object):
             len(pattoo_db_records_lists_tuple))
         log.log2debug(20009, log_message)
 
-        # ENGINE.dispose()
-
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
 
@@ -214,8 +212,6 @@ class Records(object):
             # Process data
             self.multiprocess_data()
 
-            # Dispose of any connections as a multiprocessing protection
-            ENGINE.dispose()
         else:
             # Process pairs
             self.singleprocess_pairs()
@@ -237,9 +233,6 @@ def _process_kvps_exception(pattoo_db_records):
         None
 
     """
-    # Dispose of any connections as a multiprocessing protection
-    # ENGINE.dispose()
-
     # Initialize key variables
     result = []
 
@@ -276,9 +269,6 @@ def _process_data_exception(pattoo_db_records):
     """
     # Initialize key variables
     success = False
-
-    # Dispose of any connections as a multiprocessing protection
-    # ENGINE.dispose()
 
     # Execute
     try:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -149,15 +149,15 @@ class Records(object):
 
             # Create sub processes from the pool
             results = pool.starmap(
-                process_db_records, pattoo_db_records_lists_tuple)
+                _process_data_exception, pattoo_db_records_lists_tuple)
 
         # Wait for all the processes to end and get results
         pool.join()
 
         # Test for exceptions
-        '''for result in results:
+        for result in results:
             if isinstance(result, ExceptionWrapper):
-                result.re_raise()'''
+                result.re_raise()
 
     def singleprocess_pairs(self):
         """Update rows in the Pair database table if necessary.
@@ -269,6 +269,7 @@ def _process_data_exception(pattoo_db_records):
     """
     # Initialize key variables
     success = False
+    return True
 
     # Execute
     try:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -321,6 +321,8 @@ def process_db_records(pattoo_db_records):
     agent_id = pattoo_db_records[0].pattoo_agent_id
     checksum_table = misc.agent_checksums(agent_id)
 
+    return True
+
     # Process data
     for pdbr in pattoo_db_records:
         # We only want to insert non-string, non-None values
@@ -350,8 +352,6 @@ def process_db_records(pattoo_db_records):
                 glue.insert_rows(idx_datapoint, idx_pairs)
             else:
                 continue
-
-        continue
 
         # Append item to items
         if pdbr.pattoo_timestamp > checksum_table[

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -214,6 +214,8 @@ class Records(object):
             # Process data
             self.multiprocess_data()
 
+            # Dispose of any connections as a multiprocessing protection
+            ENGINE.dispose()
         else:
             # Process pairs
             self.singleprocess_pairs()

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -237,6 +237,20 @@ def _process_kvps_exception(pattoo_db_records):
     # Initialize key variables
     result = []
 
+    '''
+    Sleep for a short random time. We have seen where on very fast systems
+    SQLAlchemy will hang the creation of multiprocessing subprocesses. The
+    typical behaviour is the creation of one fewer
+    pattoo.db._add_engine_pidguard() log messages than agents to process.
+    These messages correspond to the creation of a subprocess which immediately
+    invalidates a parent process's DB connection that will cause errors
+    if used, which provided the clue to the source of the problem.
+
+    Though SQLAlchemy isn't used by key_value_pairs. It's added as a
+    future precaution in case it does.
+    '''
+    time.sleep(random.random())
+
     # Execute
     try:
         result = get.key_value_pairs(pattoo_db_records)

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -311,7 +311,6 @@ def process_db_records(pattoo_db_records):
     # Initialize key variables
     _data = {}
     success = False
-    return True
 
     # Return if there is nothint to process
     if bool(pattoo_db_records) is False:
@@ -351,6 +350,8 @@ def process_db_records(pattoo_db_records):
                 glue.insert_rows(idx_datapoint, idx_pairs)
             else:
                 continue
+
+    return True
 
         # Append item to items
         if pdbr.pattoo_timestamp > checksum_table[

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -321,8 +321,6 @@ def process_db_records(pattoo_db_records):
     agent_id = pattoo_db_records[0].pattoo_agent_id
     checksum_table = misc.agent_checksums(agent_id)
 
-    return True
-
     # Process data
     for pdbr in pattoo_db_records:
         # We only want to insert non-string, non-None values

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -236,7 +236,7 @@ def _process_kvps_exception(pattoo_db_records):
 
     """
     # Dispose of any connections as a multiprocessing protection
-    ENGINE.dispose()
+    # ENGINE.dispose()
 
     # Initialize key variables
     result = []
@@ -276,7 +276,7 @@ def _process_data_exception(pattoo_db_records):
     success = False
 
     # Dispose of any connections as a multiprocessing protection
-    ENGINE.dispose()
+    # ENGINE.dispose()
 
     # Execute
     try:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -144,8 +144,8 @@ class Records(object):
             len(pattoo_db_records_lists_tuple))
         log.log2debug(20009, log_message)
 
-        ENGINE.dispose()
-        
+        # ENGINE.dispose()
+
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
 
@@ -349,7 +349,8 @@ def process_db_records(pattoo_db_records):
                 checksum_table[
                     pdbr.pattoo_checksum] = ChecksumLookup(
                         idx_datapoint=idx_datapoint,
-                        polling_interval=pdbr.pattoo_agent_polling_interval,
+                        polling_interval=int(
+                            pdbr.pattoo_agent_polling_interval),
                         last_timestamp=1)
 
                 # Update the Glue table
@@ -375,7 +376,7 @@ def process_db_records(pattoo_db_records):
                 pdbr.pattoo_timestamp,
                 idx_datapoint)] = IDXTimestampValue(
                     idx_datapoint=idx_datapoint,
-                    polling_interval=pdbr.pattoo_agent_polling_interval,
+                    polling_interval=int(pdbr.pattoo_agent_polling_interval),
                     timestamp=pdbr.pattoo_timestamp,
                     value=pdbr.pattoo_value)
 

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -321,6 +321,8 @@ def process_db_records(pattoo_db_records):
     agent_id = pattoo_db_records[0].pattoo_agent_id
     checksum_table = misc.agent_checksums(agent_id)
 
+    return True
+
     # Process data
     for pdbr in pattoo_db_records:
         # We only want to insert non-string, non-None values

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -144,6 +144,8 @@ class Records(object):
             len(pattoo_db_records_lists_tuple))
         log.log2debug(20009, log_message)
 
+        ENGINE.dispose()
+        
         # Create a pool of sub process resources
         with multiprocessing.Pool(processes=pool_size) as pool:
 

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -316,12 +316,12 @@ def process_db_records(pattoo_db_records):
     if bool(pattoo_db_records) is False:
         return success
 
+    return True
+
     # Get DataPoint.idx_datapoint and idx_pair values from db. This is used to
     # speed up the process by reducing the need for future database access.
     agent_id = pattoo_db_records[0].pattoo_agent_id
     checksum_table = misc.agent_checksums(agent_id)
-
-    return True
 
     # Process data
     for pdbr in pattoo_db_records:

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -351,7 +351,7 @@ def process_db_records(pattoo_db_records):
             else:
                 continue
 
-    return True
+        continue
 
         # Append item to items
         if pdbr.pattoo_timestamp > checksum_table[

--- a/pattoo/ingest/records.py
+++ b/pattoo/ingest/records.py
@@ -149,15 +149,15 @@ class Records(object):
 
             # Create sub processes from the pool
             results = pool.starmap(
-                _process_data_exception, pattoo_db_records_lists_tuple)
+                process_db_records, pattoo_db_records_lists_tuple)
 
         # Wait for all the processes to end and get results
         pool.join()
 
         # Test for exceptions
-        for result in results:
+        '''for result in results:
             if isinstance(result, ExceptionWrapper):
-                result.re_raise()
+                result.re_raise()'''
 
     def singleprocess_pairs(self):
         """Update rows in the Pair database table if necessary.


### PR DESCRIPTION
We had to add a "Sleep" for a short random time on invoking multiprocessing to db updates. We have seen where on very fast systems SQLAlchemy will hang the creation of multiprocessing subprocesses. The typical behaviour is the creation of one fewer pattoo.db._add_engine_pidguard() log messages than agents to process. These messages correspond to the creation of a subprocess which immediately invalidates a parent process's DB connection that will cause errors if used, which provided the clue to the source of the problem.