### PR TITLE
Slight modifications to installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - mysql -e 'CREATE DATABASE pattoo_unittest;'
 
 install:
-    - setup/pattoo_installation.py install database --verbose
+    - setup/install.py install database --verbose
 
 # Run the unittest scripts
 script:

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -3,7 +3,7 @@
 #############################################
 
 # Pattoo packages
-PattooShared==0.0.94
+PattooShared>=0.0.94
 
 # Miscellaneous packages
 PyYAML

--- a/setup/_pattoo/configure.py
+++ b/setup/_pattoo/configure.py
@@ -2,7 +2,7 @@
 
 # Main python libraries
 import os
-import getpass
+from _pattoo import shared as _shared
 from pattoo_shared.installation import configure, shared
 from pattoo_shared import files
 
@@ -71,7 +71,7 @@ def install(pattoo_home):
     # Attempt to create configuration directory
     files.mkdir(config_directory)
 
-    if getpass.getuser() == 'root':
+    if _shared.root_check() is True:
         # Create the pattoo user and group
         configure.create_user('pattoo', pattoo_home, '/bin/false', True)
 

--- a/setup/_pattoo/configure.py
+++ b/setup/_pattoo/configure.py
@@ -71,7 +71,7 @@ def install(pattoo_home):
     # Attempt to create configuration directory
     files.mkdir(config_directory)
 
-    if getpass.getuser() != 'travis':
+    if getpass.getuser() == 'root':
         # Create the pattoo user and group
         configure.create_user('pattoo', pattoo_home, '/bin/false', True)
 

--- a/setup/_pattoo/shared.py
+++ b/setup/_pattoo/shared.py
@@ -3,6 +3,7 @@
 import sys
 import subprocess
 import traceback
+import getpass
 
 
 def run_script(cli_string, die=True, verbose=True):
@@ -78,6 +79,22 @@ Bug: Exception Type:{}, Exception Instance: {}, Stack Trace Object: {}]\
 
     # Return
     return (returncode, stdoutdata, stderrdata)
+
+
+def root_check():
+    """Check if the user is root.
+
+    Args:
+        None
+
+    Returns:
+        True: If the user is root
+        False: If the user is not root
+    """
+    if getpass.getuser() == 'root':
+        return True
+    else:
+        return False
 
 
 def log(message):

--- a/setup/install.py
+++ b/setup/install.py
@@ -392,7 +392,8 @@ def main():
         # Set up essentials for creating the virtualenv
         pattoo_home = get_pattoo_home()
         venv_dir = os.path.join(pattoo_home, 'pattoo-venv')
-        environment.environment_setup(venv_dir)
+        if getpass.getuser() != 'travis':
+            environment.environment_setup(venv_dir)
         venv_interpreter = os.path.join(venv_dir, 'bin/python3')
         installation_dir = '{} {}'.format(venv_interpreter, ROOT_DIR)
 

--- a/setup/pattoo_installation.py
+++ b/setup/pattoo_installation.py
@@ -317,8 +317,7 @@ def installation_checks():
     # Check user
     if getpass.getuser() != 'travis':
         if getpass.getuser() != 'root':
-            shared.log('You are currently not running the script as root.\
-Run as root to continue')
+            print('Assuming configuration for unittesting')
         # Check installation directory
         if os.getcwd().startswith('/home'):
             shared.log('''\
@@ -359,7 +358,7 @@ def main():
         from pattoo_shared.installation import packages, systemd, environment
 
         # Setup virtual environment
-        if getpass.getuser() != 'travis':
+        if getpass.getuser() == 'root':
             pattoo_home = get_pattoo_home()
             venv_dir = os.path.join(pattoo_home, 'pattoo-venv')
             environment.environment_setup(venv_dir)
@@ -380,10 +379,11 @@ def main():
             # Import db after pip3 packages are installed
             from _pattoo import db
             db.install()
-            systemd.install(daemon_list=daemon_list,
-                            template_dir=template_dir,
-                            installation_dir=installation_dir,
-                            verbose=args.verbose)
+            if getpass.getuser() == 'root':
+                systemd.install(daemon_list=daemon_list,
+                                template_dir=template_dir,
+                                installation_dir=installation_dir,
+                                verbose=args.verbose)
 
         # Configures pattoo and sets up database tables
         elif args.qualifier == 'database':
@@ -397,10 +397,13 @@ def main():
         # Installs and starts system daemons
         elif args.qualifier == 'systemd':
             print('Installing systemd daemons')
-            systemd.install(daemon_list=daemon_list,
-                            template_dir=template_dir,
-                            installation_dir=installation_dir,
-                            verbose=True)
+            if getpass.getuser() == 'root':
+                systemd.install(daemon_list=daemon_list,
+                                template_dir=template_dir,
+                                installation_dir=installation_dir,
+                                verbose=True)
+            else:
+                shared.log('You need to be running as root to install the daemons')
 
         elif args.qualifier == 'pip':
             # Installs additionally required pip3 packages

--- a/setup/pattoo_installation.py
+++ b/setup/pattoo_installation.py
@@ -110,9 +110,11 @@ class _Install():
     def __init__(self, subparsers, width=80):
         """Intialize the class."""
         # Initialize key variables
+        help_message = '''\
+Install pattoo. Type install --help to see additional arguments'''
         parser = subparsers.add_parser(
             'install',
-            help=textwrap.fill('Install pattoo.', width=width)
+            help=textwrap.fill(help_message, width=width)
         )
         # Add subparser
         self.subparsers = parser.add_subparsers(dest='qualifier')


### PR DESCRIPTION
Modified installation to allow for a non-root user to install pattoo for unittesting so that the database tables can be created.
n.b) If the pattoo configdir is set to its default when the user isn't running as root, the installation will stop since the normal user won't have access to /etc/pattoo

In pattoo shared the following were resolved:
Fixed #345
Fixed #346 
Fixed #348
Fixed #349
Fixed: #350